### PR TITLE
feat: station support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.4.1",
     "@commitlint/config-conventional": "^19.4.1",
-    "@na-ji/pogo-protos": "^2.149.0",
+    "@na-ji/pogo-protos": "^2.151.0",
     "@rollup/plugin-typescript": "^11.1.6",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^19.4.1
         version: 19.4.1
       '@na-ji/pogo-protos':
-        specifier: ^2.149.0
-        version: 2.149.0
+        specifier: ^2.151.0
+        version: 2.151.0
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.13.0)(tslib@2.6.2)(typescript@5.5.4)
@@ -571,8 +571,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@na-ji/pogo-protos@2.149.0':
-    resolution: {integrity: sha512-0fb2Fn7S+xlhjAe43C+L+fbNpDYgfOpmWPDHRMAGywBObqniIDeFCpdTtuA2jSsB1OuZyws0rHmOqQJp2MUqdQ==}
+  '@na-ji/pogo-protos@2.151.0':
+    resolution: {integrity: sha512-9IBw6lvFxv4sLKyNhGR+YudA45RrSiHeupZXTCrDkpo6dEE9q8x62V4zcEdm7VFGrSlJw4YjG7If/npiTvJC/w==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3753,7 +3753,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@na-ji/pogo-protos@2.149.0':
+  '@na-ji/pogo-protos@2.151.0':
     dependencies:
       protobufjs: 6.11.4
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface UiconsIndex<T extends string[] = string[]> {
   }
   reward?: { [key in RewardTypeKeys]?: T }
   spawnpoint?: T
+  station?: T
   team?: T
   type?: T
   weather?: T

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -192,7 +192,10 @@ describe('spawnpoint', () => {
 })
 
 describe('stations', () => {
-  test('0.ext', () => {
+  test('active', () => {
+    expect(icons.station(true)).toBe(`${BASE_ICON_URL}/station/1.webp`)
+  })
+  test('inactive', () => {
     expect(icons.station()).toBe(`${BASE_ICON_URL}/station/0.webp`)
   })
 })

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -191,6 +191,12 @@ describe('spawnpoint', () => {
   })
 })
 
+describe('stations', () => {
+  test('0.ext', () => {
+    expect(icons.station()).toBe(`${BASE_ICON_URL}/station/0.webp`)
+  })
+})
+
 describe('team', () => {
   test('instinct', () => {
     expect(icons.team(3)).toBe(`${BASE_ICON_URL}/team/3.webp`)

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -557,12 +557,15 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   }
 
   /**
+   * @param active if the station is active or not
    * @returns the src of the station icon
    */
-  station(): string {
+  station(active = false): string {
     if (!this.#isReady('station')) return ''
 
-    return `${this.#path}/station/0.${this.#extensionMap.station}`
+    return `${this.#path}/station/${active ? 1 : 0}.${
+      this.#extensionMap.station
+    }`
   }
 
   /**

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -52,6 +52,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   #raid: { egg: Set<Index['raid']['egg'][number]> }
   #reward: { [key in RewardTypeKeys]?: Set<Index['reward'][key][number]> }
   #spawnpoint: Set<Index['spawnpoint'][number]>
+  #station: Set<Index['station'][number]>
   #team: Set<Index['team'][number]>
   #type: Set<Index['type'][number]>
   #weather: Set<Index['weather'][number]>
@@ -110,8 +111,10 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     )
   }
 
-  #isReady() {
+  #isReady(key?: keyof ExtensionMap): boolean {
     if (!this.#extensionMap) throw new Error('UICONS not initialized')
+    if (key && !this.#extensionMap[key]) return false
+    return true
   }
 
   /**
@@ -148,6 +151,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
         .map(([k, v]) => [k, new Set(v)])
     )
     this.#spawnpoint = new Set(data.spawnpoint || [])
+    this.#station = new Set(data.station || [])
     this.#team = new Set(data.team || [])
     this.#type = new Set(data.type || [])
     this.#weather = new Set(data.weather || [])
@@ -191,6 +195,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
         return this.#spawnpoint.has(
           `${fileName}.${this.#extensionMap.spawnpoint}`
         )
+      case 'station':
+        return this.#station.has(`${fileName}.${this.#extensionMap.station}`)
       case 'team':
         return this.#team.has(`${fileName}.${this.#extensionMap.team}`)
       case 'type':
@@ -207,7 +213,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
    * @returns the src of the device icon
    */
   device(online = false): string {
-    this.#isReady()
+    if (!this.#isReady('device')) return ''
+
     return online && this.#device.has(`1.${this.#extensionMap.device}`)
       ? `${this.#path}/device/1.${this.#extensionMap.device}`
       : `${this.#path}/device/0.${this.#extensionMap.device}`
@@ -242,7 +249,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     ex = false,
     ar = false
   ): string {
-    this.#isReady()
+    if (!this.#isReady('gym')) return ''
+
     const baseUrl = `${this.#path}/gym`
 
     const trainerSuffixes = trainerCount ? [`_t${trainerCount}`, ''] : ['']
@@ -277,7 +285,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   ): string
   invasion(gruntId?: string | number, confirmed?: boolean): string
   invasion(gruntId = 0, confirmed = false): string {
-    this.#isReady()
+    if (!this.#isReady('invasion')) return ''
+
     const baseUrl = `${this.#path}/invasion`
 
     const confirmedSuffixes = confirmed ? [''] : ['_u', '']
@@ -297,7 +306,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
    * @returns the src of the misc icon
    */
   misc(fileName?: string | number): string {
-    this.#isReady()
+    if (!this.#isReady('misc')) return ''
+
     const baseUrl = `${this.#path}/misc`
 
     if (this.#misc.has(`${fileName}.${this.#extensionMap.misc}`)) {
@@ -313,7 +323,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   nest(typeId?: EnumVal<typeof Rpc.HoloPokemonType>): string
   nest(typeId?: string | number): string
   nest(typeId = 0): string {
-    this.#isReady()
+    if (!this.#isReady('nest')) return ''
+
     const baseUrl = `${this.#path}/nest`
 
     const result = `${typeId}.${this.#extensionMap.nest}`
@@ -360,7 +371,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     alignment = 0,
     shiny = false
   ): string {
-    this.#isReady()
+    if (!this.#isReady('pokemon')) return ''
+
     const baseUrl = `${this.#path}/pokemon`
 
     const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
@@ -426,7 +438,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     questActive = false,
     ar = false
   ): string {
-    this.#isReady()
+    if (!this.#isReady('pokestop')) return ''
+
     const baseUrl = `${this.#path}/pokestop`
 
     const invasionSuffixes =
@@ -465,7 +478,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   ): string
   raidEgg(level?: string | number, hatched?: boolean, ex?: boolean): string
   raidEgg(level = 0, hatched = false, ex = false): string {
-    this.#isReady()
+    if (!this.#isReady('raid')) return ''
+
     const baseUrl = `${this.#path}/raid/egg`
 
     const hatchedSuffixes = hatched ? ['_h', ''] : ['']
@@ -503,7 +517,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     rewardId = 0,
     amount = 0
   ): string {
-    this.#isReady()
+    if (!this.#isReady('reward')) return ''
+
     const baseUrl = `${this.#path}/reward/${questRewardType}`
     const rewardSet = this.#reward[questRewardType]
     if (!rewardSet) {
@@ -534,10 +549,20 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
    * @returns the src of the spawnpoint icon
    */
   spawnpoint(hasTth = false): string {
-    this.#isReady()
+    if (!this.#isReady('spawnpoint')) return ''
+
     return hasTth && this.#spawnpoint.has(`1.${this.#extensionMap.spawnpoint}`)
       ? `${this.#path}/spawnpoint/1.${this.#extensionMap.spawnpoint}`
       : `${this.#path}/spawnpoint/0.${this.#extensionMap.spawnpoint}`
+  }
+
+  /**
+   * @returns the src of the station icon
+   */
+  station(): string {
+    if (!this.#isReady('station')) return ''
+
+    return `${this.#path}/station/0.${this.#extensionMap.station}`
   }
 
   /**
@@ -547,7 +572,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   team(teamId?: EnumVal<typeof Rpc.Team>): string
   team(teamId?: string | number): string
   team(teamId = 0): string {
-    this.#isReady()
+    if (!this.#isReady('team')) return ''
+
     const baseUrl = `${this.#path}/team`
 
     const result = `${teamId}.${this.#extensionMap.team}`
@@ -564,7 +590,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   type(typeId?: EnumVal<typeof Rpc.HoloPokemonType>): string
   type(typeId?: string | number): string
   type(typeId = 0): string {
-    this.#isReady()
+    if (!this.#isReady('type')) return ''
+
     const baseUrl = `${this.#path}/type`
 
     const result = `${typeId}.${this.#extensionMap.type}`
@@ -585,7 +612,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   ): string
   weather(weatherId?: string | number, timeOfDay?: string): string
   weather(weatherId = 0, timeOfDay = 'day'): string {
-    this.#isReady()
+    if (!this.#isReady('weather')) return ''
+
     const baseUrl = `${this.#path}/weather`
 
     const timeSuffixes = timeOfDay === 'night' ? ['_n', ''] : ['_d', '']


### PR DESCRIPTION
Adds support for the new root `station` folder. Merge is pending the merge of the UICONS standard and once I add images to the remote repos so tests will pass.

This also changes the private `#isReady` function a bit. In the case that a folder is missing, as will likely be the case for many uicons repos for `station` for a bit, the functions will instead return an empty string for more convenient checks from users.