### PR TITLE
2.0 Changes - including `_b` flag for pokemon bread forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,35 +41,36 @@ const indexJson = await fetch('https://www.uicons-repo.com/index.json').then(
 uicons.init(indexJson)
 
 // Below are some example usages with variable names for demonstration, see intellisense in your IDE for type information
+// Please note that in some cases, such as with Stardust, the `reward_id` is the `amount` of the reward
+const device = uicons.device(online)
+const gym = uicons.gym(team_id, trainer_count, in_battle, ex, ar, power_level)
+const invasion = uicons.invasion(grunt_id, confirmed)
+const misc = uicons.misc(filename_without_extension)
+const nest = uicons.nest(type_id)
 const pokemon = uicons.pokemon(
   pokemon_id,
-  form_id,
   evolution_id,
-  gender_id,
+  form_id,
   costume_id,
+  gender_id,
   alignment_id,
+  bread_id,
   shiny
 )
-const type = uicons.type(type_id)
 const pokestop = uicons.pokestop(
   lure_id,
-  power,
   display,
-  invasion_active,
   quest_active,
   ar
+  power,
 )
-// Please note that in some cases, such as with Stardust, the `reward_id` is the `amount` of the reward
+const egg = uicons.raidEgg(raid_level, hatched, ex)
 const reward = uicons.reward(reward_type_id, reward_id, amount)
-const invasion = uicons.invasion(grunt_id, confirmed)
-const gym = uicons.gym(team_id, trainer_count, in_battle, ex, ar)
-const egg = uicons.egg(raid_level, hatched, ex)
-const team = uicons.team(team_id)
-const weather = uicons.weather(weather_id)
-const nest = uicons.nest(type_id)
-const misc = uicons.misc(filename_without_extension)
-const device = uicons.device(online)
+const rewardWithOutId = uicons.reward(reward_type_id, amount)
 const spawnpoint = uicons.spawnpoint(has_known_tth)
+const team = uicons.team(team_id)
+const type = uicons.type(type_id)
+const weather = uicons.weather(weather_id, severity, 'day')
 ```
 
 ## Development

--- a/example/utils.ts
+++ b/example/utils.ts
@@ -41,8 +41,8 @@ export async function getMonsFromMf(
     if (evo) title += `_${evo}`
     return {
       title,
-      src: newUicons.pokemon(id, form, evo),
-      cry: newUaudio.pokemon(id, form, evo),
+      src: newUicons.pokemon(id, evo, form),
+      cry: newUaudio.pokemon(id, evo, form),
     }
   })
 }
@@ -79,11 +79,21 @@ export async function getMonsFromIndex(
         const evo = parseArgs(rest, '_e') ?? 0
         const gender = parseArgs(rest, '_g') ?? 0
         const alignment = parseArgs(rest, '_a') ?? 0
-        const shiny = !!parseArgs(rest, '_s')
+        const bread = parseArgs(rest, '_b') ?? 0
+        const shiny = !!parseArgs(rest, '_s') ?? false
         return {
           title,
           src: `${icon.path}/pokemon/${file}`,
-          cry: newUaudio.pokemon(id, form, evo, gender, 0, alignment, shiny),
+          cry: newUaudio.pokemon(
+            id,
+            evo,
+            form,
+            0,
+            gender,
+            alignment,
+            bread,
+            shiny
+          ),
         }
       }) || []
   )

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -89,13 +89,12 @@ describe('pokemon', () => {
     expect(icons.pokemon('1')).toBe(`${BASE_ICON_URL}/pokemon/1.webp`)
   })
   test('charmander form', () => {
-    expect(icons.pokemon(4, 896)).toBe(`${BASE_ICON_URL}/pokemon/4_f896.webp`)
+    expect(icons.pokemon(4, 0, 896)).toBe(`${BASE_ICON_URL}/pokemon/4_f896.webp`)
   })
   test('mega blastoise', () => {
     expect(
       icons.pokemon(
         Rpc.HoloPokemonId.BLASTOISE,
-        Rpc.PokemonDisplayProto.Form.FORM_UNSET,
         Rpc.HoloTemporaryEvolutionId.TEMP_EVOLUTION_MEGA
       )
     ).toBe(`${BASE_ICON_URL}/pokemon/9_e1.webp`)

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -89,7 +89,9 @@ describe('pokemon', () => {
     expect(icons.pokemon('1')).toBe(`${BASE_ICON_URL}/pokemon/1.webp`)
   })
   test('charmander form', () => {
-    expect(icons.pokemon(4, 0, 896)).toBe(`${BASE_ICON_URL}/pokemon/4_f896.webp`)
+    expect(icons.pokemon(4, 0, 896)).toBe(
+      `${BASE_ICON_URL}/pokemon/4_f896.webp`
+    )
   })
   test('mega blastoise', () => {
     expect(
@@ -225,11 +227,11 @@ describe('weather', () => {
     expect(icons.weather(2)).toBe(`${BASE_ICON_URL}/weather/2.webp`)
   })
   test('with day', () => {
-    expect(icons.weather(3, 'day')).toBe(`${BASE_ICON_URL}/weather/3_d.webp`)
+    expect(icons.weather(3, 0, 'day')).toBe(`${BASE_ICON_URL}/weather/3_d.webp`)
   })
   test('with night', () => {
     expect(
-      icons.weather(Rpc.GameplayWeatherProto.WeatherCondition.CLEAR, 'night')
+      icons.weather(Rpc.GameplayWeatherProto.WeatherCondition.CLEAR, 0, 'night')
     ).toBe(`${BASE_ICON_URL}/weather/1_n.webp`)
   })
 })

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -107,17 +107,15 @@ describe('pokestops', () => {
     expect(icons.pokestop(501)).toBe(`${BASE_ICON_URL}/pokestop/501.webp`)
   })
   test('invasion', () => {
-    expect(icons.pokestop(0, 0, 0, true)).toBe(
-      `${BASE_ICON_URL}/pokestop/0_i.webp`
-    )
+    expect(icons.pokestop(0, 0)).toBe(`${BASE_ICON_URL}/pokestop/0_i.webp`)
   })
   test('quest', () => {
-    expect(icons.pokestop(0, 0, 0, false, true)).toBe(
+    expect(icons.pokestop(0, false, 0)).toBe(
       `${BASE_ICON_URL}/pokestop/0_q.webp`
     )
   })
   test('ar', () => {
-    expect(icons.pokestop(504, 0, 0, true, false, true)).toBe(
+    expect(icons.pokestop(504, 0, false, true)).toBe(
       `${BASE_ICON_URL}/pokestop/504_i_ar.webp`
     )
   })

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -336,40 +336,44 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
 
   /**
    * @param pokemonId the pokemon ID
-   * @param form the form ID of the pokemon, @see Rpc.PokemonDisplayProto.Form
    * @param evolution the [mega] evolution ID of the pokemon, @see Rpc.HoloTemporaryEvolutionId
-   * @param gender the gender ID of the pokemon, @see Rpc.PokemonDisplayProto.PokemonGender
+   * @param form the form ID of the pokemon, @see Rpc.PokemonDisplayProto.Form
    * @param costume the costume ID of the pokemon, @see Rpc.PokemonDisplayProto.Costume
+   * @param gender the gender ID of the pokemon, @see Rpc.PokemonDisplayProto.PokemonGender
    * @param alignment the alignment ID of the pokemon, such as shadow or purified, @see Rpc.PokemonDisplayProto.Alignment
+   * @param bread the bread mode of the pokemon, @see Rpc.BreadModeEnum.Modifier
    * @param shiny if the pokemon is shiny
    * @returns the src of the pokemon icon
    */
   pokemon(
     pokemonId?: EnumVal<typeof Rpc.HoloPokemonId>,
-    form?: EnumVal<typeof Rpc.PokemonDisplayProto.Form>,
     evolution?: EnumVal<typeof Rpc.HoloTemporaryEvolutionId>,
-    gender?: EnumVal<typeof Rpc.PokemonDisplayProto.Gender>,
+    form?: EnumVal<typeof Rpc.PokemonDisplayProto.Form>,
     costume?: EnumVal<typeof Rpc.PokemonDisplayProto.Costume>,
+    gender?: EnumVal<typeof Rpc.PokemonDisplayProto.Gender>,
     alignment?: EnumVal<typeof Rpc.PokemonDisplayProto.Alignment>,
-    shiny?: boolean
+    bread?: EnumVal<typeof Rpc.BreadModeEnum.Modifier>,
+    shiny?: boolean,
   ): string
   pokemon(
     pokemonId?: string | number,
-    form?: string | number,
     evolution?: string | number,
-    gender?: string | number,
+    form?: string | number,
     costume?: string | number,
+    gender?: string | number,
     alignment?: string | number,
-    shiny?: boolean
+    bread?: string | number,
+    shiny?: boolean,
   ): string
   pokemon(
     pokemonId = 0,
-    form = 0,
     evolution = 0,
-    gender = 0,
+    form = 0,
     costume = 0,
+    gender = 0,
     alignment = 0,
-    shiny = false
+    bread = 0,
+    shiny = false,
   ): string {
     if (!this.#isReady('pokemon')) return ''
 
@@ -380,6 +384,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
     const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
     const alignmentSuffixes = alignment ? [`_a${alignment}`, ''] : ['']
+    const breadSuffixes = bread ? [`_b${bread}`, ''] : ['']
     const shinySuffixes = shiny ? ['_s', ''] : ['']
 
     for (let e = 0; e < evolutionSuffixes.length; e += 1) {
@@ -387,14 +392,18 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
         for (let c = 0; c < costumeSuffixes.length; c += 1) {
           for (let g = 0; g < genderSuffixes.length; g += 1) {
             for (let a = 0; a < alignmentSuffixes.length; a += 1) {
-              for (let s = 0; s < shinySuffixes.length; s += 1) {
-                const result = `${pokemonId}${evolutionSuffixes[e]}${
-                  formSuffixes[f]
-                }${costumeSuffixes[c]}${genderSuffixes[g]}${
-                  alignmentSuffixes[a]
-                }${shinySuffixes[s]}.${this.#extensionMap.pokemon}`
-                if (this.#pokemon.has(result)) {
-                  return `${baseUrl}/${result}`
+              for (let b = 0; b < breadSuffixes.length; b += 1) {
+                for (let s = 0; s < shinySuffixes.length; s += 1) {
+                  const result = `${pokemonId}${evolutionSuffixes[e]}${
+                    formSuffixes[f]
+                  }${costumeSuffixes[c]}${genderSuffixes[g]}${
+                    alignmentSuffixes[a]
+                  }${breadSuffixes[b]}${shinySuffixes[s]}.${
+                    this.#extensionMap.pokemon
+                  }`
+                  if (this.#pokemon.has(result)) {
+                    return `${baseUrl}/${result}`
+                  }
                 }
               }
             }

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -536,7 +536,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   ): string
   reward<U extends RewardTypeKeys>(
     questRewardType: U = 'unset' as U,
-    rewardId = 0,
+    rewardIdOrAmount = 0,
     amount = 0
   ): string {
     if (!this.#isReady('reward')) return ''
@@ -553,7 +553,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
       Number.isInteger(amountSafe) && amountSafe > 1
         ? [`_a${amount}`, '']
         : ['']
-    const safeId = +rewardId || amountSafe || 0
+    const safeId = +rewardIdOrAmount || amountSafe || 0
 
     for (let a = 0; a < amountSuffixes.length; a += 1) {
       const result = `${safeId}${amountSuffixes[a]}.${

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -445,21 +445,21 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     displayTypeId?: boolean | EnumVal<typeof Rpc.IncidentDisplayType>,
     questActive?: boolean | string | number,
     ar?: boolean,
-    power?: EnumVal<typeof Rpc.FortPowerUpLevel>
+    power?: boolean | EnumVal<typeof Rpc.FortPowerUpLevel>
   ): string
   pokestop(
     lureId?: string | number,
     displayTypeId?: boolean | string | number,
     questActive?: boolean | string | number,
     ar?: boolean,
-    power?: string | number
+    power?: boolean | string | number
   ): string
   pokestop(
     lureId = 0,
     displayTypeId = false,
     questActive = false,
     ar = false,
-    power = 0
+    power = false
   ): string {
     if (!this.#isReady('pokestop')) return ''
 
@@ -468,7 +468,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     const displaySuffixes = this.#evalPossiblyEmptyFlag('_i', displayTypeId)
     const questSuffixes = this.#evalPossiblyEmptyFlag('_q', questActive)
     const arSuffixes = ar ? ['_ar', ''] : ['']
-    const powerUpSuffixes = power ? [`_p${power}`, ''] : ['']
+    const powerUpSuffixes = this.#evalPossiblyEmptyFlag('_p', power)
 
     for (let i = 0; i < displaySuffixes.length; i += 1) {
       for (let q = 0; q < questSuffixes.length; q += 1) {

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -117,6 +117,14 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     return true
   }
 
+  #evalPossiblyEmptyFlag(flag: string, value: boolean | string | number) {
+    return typeof value === 'number'
+      ? [`${flag}${value || ''}`, '']
+      : value
+      ? [flag, '']
+      : ['']
+  }
+
   /**
    * This is used to initialize the UICONS class asynchronously by automatically fetching the index.json file
    * from the remote UICONS repository provided in the constructor
@@ -353,7 +361,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     gender?: EnumVal<typeof Rpc.PokemonDisplayProto.Gender>,
     alignment?: EnumVal<typeof Rpc.PokemonDisplayProto.Alignment>,
     bread?: EnumVal<typeof Rpc.BreadModeEnum.Modifier>,
-    shiny?: boolean,
+    shiny?: boolean
   ): string
   pokemon(
     pokemonId?: string | number,
@@ -363,7 +371,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     gender?: string | number,
     alignment?: string | number,
     bread?: string | number,
-    shiny?: boolean,
+    shiny?: boolean
   ): string
   pokemon(
     pokemonId = 0,
@@ -373,7 +381,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     gender = 0,
     alignment = 0,
     bread = 0,
-    shiny = false,
+    shiny = false
   ): string {
     if (!this.#isReady('pokemon')) return ''
 
@@ -416,52 +424,47 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
 
   /**
    * @param lureId the ID of the lure at the pokestop, 0 for no lure, @see Rpc.TROY_DISK values in Rpc.Item
-   * @param power the power up level of the pokestop, 0 for no power up, @see Rpc.FortPowerUpLevel
-   * @param display the display ID of the pokestop, 0 for no display, @see Rpc.IncidentDisplayType
-   * @param invasionActive does the pokestop currently have an invasion
+   * @param displayTypeId the display ID of the pokestop, 0 for no display, @see Rpc.IncidentDisplayType
    * @param questActive does the pokestop currently have an active quest
    * @param ar is the pokestop AR eligible
+   * @param power the power up level of the pokestop, 0 for no power up, @see Rpc.FortPowerUpLevel
    * @returns
    */
   pokestop(
     lureId?: LureIDs,
-    power?: EnumVal<typeof Rpc.FortPowerUpLevel>,
-    display?: EnumVal<typeof Rpc.IncidentDisplayType>,
-    invasionActive?: boolean,
-    questActive?: boolean,
-    ar?: boolean
+    displayTypeId?: boolean | EnumVal<typeof Rpc.IncidentDisplayType>,
+    questActive?: boolean | string | number,
+    ar?: boolean,
+    power?: EnumVal<typeof Rpc.FortPowerUpLevel>
   ): string
   pokestop(
     lureId?: string | number,
-    power?: string | number,
-    display?: string | number,
-    invasionActive?: boolean,
-    questActive?: boolean,
-    ar?: boolean
+    displayTypeId?: boolean | string | number,
+    questActive?: boolean | string | number,
+    ar?: boolean,
+    power?: string | number
   ): string
   pokestop(
     lureId = 0,
-    power = 0,
-    display = 0,
-    invasionActive = false,
+    displayTypeId = false,
     questActive = false,
-    ar = false
+    ar = false,
+    power = 0
   ): string {
     if (!this.#isReady('pokestop')) return ''
 
     const baseUrl = `${this.#path}/pokestop`
 
-    const invasionSuffixes =
-      invasionActive || display ? [`_i${display || ''}`, ''] : ['']
-    const questSuffixes = questActive ? ['_q', ''] : ['']
+    const displaySuffixes = this.#evalPossiblyEmptyFlag('_i', displayTypeId)
+    const questSuffixes = this.#evalPossiblyEmptyFlag('_q', questActive)
     const arSuffixes = ar ? ['_ar', ''] : ['']
     const powerUpSuffixes = power ? [`_p${power}`, ''] : ['']
 
-    for (let i = 0; i < invasionSuffixes.length; i += 1) {
+    for (let i = 0; i < displaySuffixes.length; i += 1) {
       for (let q = 0; q < questSuffixes.length; q += 1) {
         for (let a = 0; a < arSuffixes.length; a += 1) {
           for (let p = 0; p < powerUpSuffixes.length; p += 1) {
-            const result = `${lureId}${invasionSuffixes[i]}${questSuffixes[q]}${
+            const result = `${lureId}${displaySuffixes[i]}${questSuffixes[q]}${
               arSuffixes[a]
             }${powerUpSuffixes[p]}.${this.#extensionMap.pokestop}`
             if (this.#pokestop.has(result)) {

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -618,26 +618,35 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
 
   /**
    * @param weatherId the weather ID, @see Rpc.GameplayWeatherProto.WeatherCondition
-   * @param timeOfDay the time of day, either 'day' or 'night'
+   * @param severityLevel the severity of the weather, @see Rpc.InternalWeatherAlertProto.Severity
+   * @param timeOfDay the time of day, @see TimeOfDay
    * @returns the src of the weather icon
    */
   weather(
     weatherId?: EnumVal<typeof Rpc.GameplayWeatherProto.WeatherCondition>,
+    severityLevel?: EnumVal<typeof Rpc.InternalWeatherAlertProto.Severity>,
     timeOfDay?: TimeOfDay
   ): string
-  weather(weatherId?: string | number, timeOfDay?: string): string
-  weather(weatherId = 0, timeOfDay = 'day'): string {
+  weather(
+    weatherId?: string | number,
+    severityLevel?: string | number,
+    timeOfDay?: string
+  ): string
+  weather(weatherId = 0, severityLevel = 0, timeOfDay = 'day'): string {
     if (!this.#isReady('weather')) return ''
 
     const baseUrl = `${this.#path}/weather`
 
+    const severitySuffixes = severityLevel ? [`_l${severityLevel}`, ''] : ['']
     const timeSuffixes = timeOfDay === 'night' ? ['_n', ''] : ['_d', '']
-    for (let t = 0; t < timeSuffixes.length; t += 1) {
-      const result = `${weatherId}${timeSuffixes[t]}.${
-        this.#extensionMap.weather
-      }`
-      if (this.#weather.has(result)) {
-        return `${baseUrl}/${result}`
+    for (let s = 0; s < severitySuffixes.length; s += 1) {
+      for (let t = 0; t < timeSuffixes.length; t += 1) {
+        const result = `${weatherId}${severitySuffixes[s]}${timeSuffixes[t]}.${
+          this.#extensionMap.weather
+        }`
+        if (this.#weather.has(result)) {
+          return `${baseUrl}/${result}`
+        }
       }
     }
     return `${baseUrl}/0.${this.#extensionMap.weather}`

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -234,6 +234,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
    * @param inBattle is the gym is in battle
    * @param ex is the gym an EX raid gym
    * @param ar is the gym AR eligible
+   * @param power the power up level of the gym, @see Rpc.FortPowerUpLevel
    * @returns the src of the gym icon
    */
   gym(
@@ -241,21 +242,24 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     trainerCount?: TrainerCounts,
     inBattle?: boolean,
     ex?: boolean,
-    ar?: boolean
+    ar?: boolean,
+    power?: boolean | EnumVal<typeof Rpc.FortPowerUpLevel>
   ): string
   gym(
     teamId?: string | number,
     trainerCount?: string | number,
     inBattle?: boolean,
     ex?: boolean,
-    ar?: boolean
+    ar?: boolean,
+    power?: boolean | string | number
   ): string
   gym(
     teamId = 0,
     trainerCount: string | number = 0,
     inBattle = false,
     ex = false,
-    ar = false
+    ar = false,
+    power = false
   ): string {
     if (!this.#isReady('gym')) return ''
 
@@ -265,15 +269,21 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     const inBattleSuffixes = inBattle ? ['_b', ''] : ['']
     const exSuffixes = ex ? ['_ex', ''] : ['']
     const arSuffixes = ar ? ['_ar', ''] : ['']
+    const powerUpSuffixes = this.#evalPossiblyEmptyFlag('_p', power)
+
     for (let t = 0; t < trainerSuffixes.length; t += 1) {
       for (let b = 0; b < inBattleSuffixes.length; b += 1) {
         for (let e = 0; e < exSuffixes.length; e += 1) {
           for (let a = 0; a < arSuffixes.length; a += 1) {
-            const result = `${teamId}${trainerSuffixes[t]}${
-              inBattleSuffixes[b]
-            }${exSuffixes[e]}${arSuffixes[a]}.${this.#extensionMap.gym}`
-            if (this.#gym.has(result)) {
-              return `${baseUrl}/${result}`
+            for (let p = 0; p < powerUpSuffixes.length; p += 1) {
+              const result = `${teamId}${trainerSuffixes[t]}${
+                inBattleSuffixes[b]
+              }${exSuffixes[e]}${arSuffixes[a]}${powerUpSuffixes[p]}.${
+                this.#extensionMap.gym
+              }`
+              if (this.#gym.has(result)) {
+                return `${baseUrl}/${result}`
+              }
             }
           }
         }


### PR DESCRIPTION
Since adding the `_b` flag was going to be a breaking change, if implemented correctly, I took the time to also update some of the other function signatures that were either missing some flag support or were in the "wrong" order. The following methods have had their function signature changed in some way:

- `gym`: added support for `_p` or power up flag (non-breaking)
- `pokemon`: changed order of arguments to match standard, plus added `_b` bread flag
  - old: `pokemon_id, form, evo, gender, costume, alignment, shiny`
  - new: `pokemon_id, evo, form, costume, gender, alignment, bread, shiny`
- `pokestop`: changed order of arguments to match standard. 
  - old: `lure_id, power, display, invasionActive, questActive, ar`
  - new: `lure_id, display (boolean | number | string), questActive (boolean | number | string), ar, power`
- `weather`: added support for `_l`  (severity level) flag, changed argument order to reflect standard
  - old: `weather_id, time_of_day`
  - new: `weather_id, severity_level, time_of_day`

Pending the merge of https://github.com/UIcons/UIcons/pull/37