### PR TITLE
feat: support temporary evolution reward icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ const pokestop = uicons.pokestop(
 )
 const egg = uicons.raidEgg(raid_level, hatched, ex)
 const reward = uicons.reward(reward_type_id, reward_id, amount)
+const evolutionReward = uicons.reward(
+  reward_type_id,
+  reward_id,
+  amount,
+  evolution_id,
+)
 const rewardWithOutId = uicons.reward(reward_type_id, amount)
 const spawnpoint = uicons.spawnpoint(has_known_tth)
 const team = uicons.team(team_id)

--- a/src/uicons.test.ts
+++ b/src/uicons.test.ts
@@ -11,6 +11,24 @@ const backgroundIcons = new UICONS({
   path: BASE_ICON_URL,
   data: { background: ['0.webp', '1.webp'] },
 })
+const branchRewardIcons = new UICONS({
+  path: BASE_ICON_URL,
+  data: {
+    reward: {
+      mega_resource: [
+        '0.webp',
+        '3.webp',
+        '6.webp',
+        '6_e2.webp',
+        '6_e2_a25.webp',
+        '26.webp',
+        '26_e3.webp',
+        '150.webp',
+        '150_a25.webp',
+      ],
+    },
+  },
+})
 
 describe('webp format', () => {
   test('should fetch remotely', async () => {
@@ -216,6 +234,31 @@ describe('reward', () => {
   test('mega_resource with amount', () => {
     expect(icons.reward('mega_resource', 6, 25)).toBe(
       `${BASE_ICON_URL}/reward/mega_resource/6_a25.webp`
+    )
+  })
+  test('mega_resource with evolution and amount', () => {
+    expect(
+      branchRewardIcons.reward(
+        'mega_resource',
+        6,
+        25,
+        Rpc.HoloTemporaryEvolutionId.TEMP_EVOLUTION_MEGA_X
+      )
+    ).toBe(`${BASE_ICON_URL}/reward/mega_resource/6_e2_a25.webp`)
+  })
+  test('mega_resource evolution falls back without amount', () => {
+    expect(branchRewardIcons.reward('mega_resource', 26, 25, 3)).toBe(
+      `${BASE_ICON_URL}/reward/mega_resource/26_e3.webp`
+    )
+  })
+  test('mega_resource falls back to generic amount', () => {
+    expect(branchRewardIcons.reward('mega_resource', 150, 25, 2)).toBe(
+      `${BASE_ICON_URL}/reward/mega_resource/150_a25.webp`
+    )
+  })
+  test('mega_resource falls back to generic Pokemon', () => {
+    expect(branchRewardIcons.reward('mega_resource', 3, 25, 2)).toBe(
+      `${BASE_ICON_URL}/reward/mega_resource/3.webp`
     )
   })
 })

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -582,12 +582,20 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
    * @param questRewardType the type of quest reward, @see Rpc.QuestRewardProto.Type
    * @param rewardId the ID or the amount of the reward. This depends on the complexity of the reward type. For example, item rewards use the item ID, while stardust rewards use the amount of stardust. Best to check uicons repository to see which of them use the `_a` flag
    * @param amount the amount of the reward
+   * @param evolution the temporary evolution ID of the reward Pokemon, @see Rpc.HoloTemporaryEvolutionId
    * @returns the src of the quest reward icon
    */
   reward<U extends RewardTypeKeys>(
     questRewardType?: U,
     rewardId?: string | number,
-    amount?: string | number
+    amount?: string | number,
+    evolution?: EnumVal<typeof Rpc.HoloTemporaryEvolutionId>
+  ): string
+  reward<U extends RewardTypeKeys>(
+    questRewardType?: U,
+    rewardId?: string | number,
+    amount?: string | number,
+    evolution?: string | number
   ): string
   reward<U extends RewardTypeKeys>(
     questRewardType?: U,
@@ -596,7 +604,8 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
   reward<U extends RewardTypeKeys>(
     questRewardType: U = 'unset' as U,
     rewardIdOrAmount = 0,
-    amount = 0
+    amount = 0,
+    evolution: string | number = 0
   ): string {
     if (!this.#isReady('reward')) return ''
 
@@ -612,14 +621,17 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
       Number.isInteger(amountSafe) && amountSafe > 1
         ? [`_a${amount}`, '']
         : ['']
+    const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
     const safeId = +rewardIdOrAmount || amountSafe || 0
 
-    for (let a = 0; a < amountSuffixes.length; a += 1) {
-      const result = `${safeId}${amountSuffixes[a]}.${
-        this.#extensionMap.reward[questRewardType]
-      }`
-      if (rewardSet.has(result)) {
-        return `${baseUrl}/${result}`
+    for (let e = 0; e < evolutionSuffixes.length; e += 1) {
+      for (let a = 0; a < amountSuffixes.length; a += 1) {
+        const result = `${safeId}${evolutionSuffixes[e]}${amountSuffixes[a]}.${
+          this.#extensionMap.reward[questRewardType]
+        }`
+        if (rewardSet.has(result)) {
+          return `${baseUrl}/${result}`
+        }
       }
     }
     return `${baseUrl}/0.${this.#extensionMap.reward[questRewardType]}`

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -605,7 +605,7 @@ export class UICONS<Index extends UiconsIndex = UiconsIndex> {
     questRewardType: U = 'unset' as U,
     rewardIdOrAmount = 0,
     amount = 0,
-    evolution: string | number = 0
+    evolution = 0
   ): string {
     if (!this.#isReady('reward')) return ''
 


### PR DESCRIPTION
## Summary

- add an optional temporary-evolution argument to `UICONS.reward()`
- resolve branch-aware reward assets with graceful fallbacks
- document the new API and add deterministic fallback tests

## Why

Mega branch resource rewards can distinguish temporary-evolution branches through `_eN` filenames, but the resolver previously generated only `{id}_a{amount}` and `{id}` candidates. That made existing Mega X/Y reward assets unreachable to consumers.

The new lookup order is:

1. `{id}_e{evolution}_a{amount}`
2. `{id}_e{evolution}`
3. `{id}_a{amount}`
4. `{id}`
5. the category fallback

Existing two- and three-argument calls retain their current behavior.

## Validation

- `npm test -- --runInBand` - 57 tests passed
- `npm run build:ts`
