### PR TITLE
fix(types): ship pogo-protos as a dependency + correct v2→v3 docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,16 +1,16 @@
-# Migrating from v1 to v2
+# Migrating from v2 to v3
 
-v2 changes the **call signatures and types only**. Runtime lookup behavior — the candidate
+v3 changes the **call signatures and types only**. Runtime lookup behavior — the candidate
 search loops, fallbacks to `0.{ext}`, and returning `''` for missing categories — is
-unchanged from v1, with two degenerate-input fixes:
+unchanged from v2, with two degenerate-input fixes:
 
 - Empty file lists in the index (e.g. `{ gym: [] }`) are now treated like missing
-  categories (`''`, or the usual fallbacks for `reward`/`tappable`). v1 produced broken
+  categories (`''`, or the usual fallbacks for `reward`/`tappable`). v2 produced broken
   `0.[object Object]` / `0.undefined` URLs for these.
-- `misc()` with no argument now looks up `0.{ext}` directly; v1 first probed the literal
+- `misc()` with no argument now looks up `0.{ext}` directly; v2 first probed the literal
   file name `undefined.{ext}`. The returned URL is identical either way.
 
-**Requires TypeScript >= 5.0** (v2 uses `const` type parameters).
+**Requires TypeScript >= 5.0** (v3 uses `const` type parameters).
 
 ## Why
 
@@ -30,10 +30,10 @@ JS callers still get the old behavior plus a dev-mode deprecation warning). Use 
 options object:
 
 ```ts
-// v1 (removed)
+// v2 (removed)
 const uicons = new UICONS('https://example.com/uicons', 'cagemons')
 
-// v2
+// v3
 const uicons = new UICONS({ path: 'https://example.com/uicons', label: 'cagemons' })
 ```
 
@@ -41,7 +41,7 @@ const uicons = new UICONS({ path: 'https://example.com/uicons', label: 'cagemons
 
 New optional `extension` option — a **type-level only** hint that narrows return types
 when the index data is not statically known (e.g. when using `remoteInit`). At runtime
-the extension is always derived from the index data, exactly as in v1:
+the extension is always derived from the index data, exactly as in v2:
 
 ```ts
 const uicons = new UICONS({ path: 'https://example.com/uicons', extension: 'webp' })
@@ -53,9 +53,9 @@ ready.team({ teamId: 1 })
 ## Method mapping
 
 `has(location, fileName)` is unchanged. Every other method takes one optional object.
-All keys are optional with the same defaults as v1.
+All keys are optional with the same defaults as v2.
 
-| v1 positional call | v2 object call |
+| v2 positional call | v3 object call |
 | --- | --- |
 | `background(backgroundId)` | `background({ id })` |
 | `device(online)` | `device({ online })` |
@@ -76,21 +76,21 @@ All keys are optional with the same defaults as v1.
 
 ### reward(): `rewardIdOrAmount` renamed to `rewardId`
 
-The second positional parameter of v1's `reward()` is now the `rewardId` key. The runtime
+The second positional parameter of v2's `reward()` is now the `rewardId` key. The runtime
 still resolves the file name from `+rewardId || +amount || 0`.
 
-Note that v1's two-arg convenience overload `reward('stardust', 500)` fed its second
+Note that v2's two-arg convenience overload `reward('stardust', 500)` fed its second
 argument into the *rewardIdOrAmount* slot, not `amount` — so the 1:1 translation is
 `rewardId`, by position, not by the overload's parameter name. Passing `amount: 500`
 instead would additionally try the `500_a500` variant first, which can resolve to a
 different file when the repository contains `_a` variants:
 
 ```ts
-// v1
+// v2
 uicons.reward('item', 1)
 uicons.reward('stardust', 500)          // two-arg convenience overload
 
-// v2
+// v3
 uicons.reward({ questRewardType: 'item', rewardId: 1 })
 uicons.reward({ questRewardType: 'stardust', rewardId: 500 })
 ```

--- a/example/Features.tsx
+++ b/example/Features.tsx
@@ -32,7 +32,7 @@ const FEATURES: Feature[] = [
   {
     icon: <Feather />,
     title: 'Zero runtime deps',
-    body: 'Pure string building over a Set. Nothing to audit, nothing to bundle. Ships ESM + CJS with full .d.ts.',
+    body: 'Pure string building over a Set. Its one dependency is type-only, so nothing extra ships in your bundle. ESM + CJS with full .d.ts.',
     span: 'std',
   },
   {
@@ -80,7 +80,7 @@ export function Features() {
       <div className="section-head reveal" ref={head}>
         <span className="eyebrow">
           <span className="dot" />
-          Why v2
+          Why v3
         </span>
         <h2 className="h2">
           Boring to call.

--- a/example/Hero.tsx
+++ b/example/Hero.tsx
@@ -35,7 +35,7 @@ export function Hero() {
         <div className="reveal" ref={ref}>
           <span className="eyebrow">
             <span className="dot" />
-            Type-safe · Zero dependencies
+            Type-safe · No runtime deps
           </span>
           <h1 className="display">
             Icons that know

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "test": "jest",
     "prepare": "husky"
   },
+  "dependencies": {
+    "@na-ji/pogo-protos": "^2.153.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
-    "@na-ji/pogo-protos": "^2.153.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@na-ji/pogo-protos':
+        specifier: ^2.153.0
+        version: 2.247.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.1
@@ -14,9 +18,6 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.2.0
         version: 21.2.0
-      '@na-ji/pogo-protos':
-        specifier: ^2.153.0
-        version: 2.247.0
       '@rollup/plugin-typescript':
         specifier: ^12.3.0
         version: 12.3.0(tslib@2.8.1)(typescript@5.9.3)


### PR DESCRIPTION
Two items from the punch list, plus a copy fix.

## 1. `@na-ji/pogo-protos` → `dependencies`

The published `.d.ts` files import types from `@na-ji/pogo-protos` (the `Rpc` enums behind the typed method arguments):

```ts
import type { Rpc } from '@na-ji/pogo-protos'
```

It was only a **devDependency**, so consumers who didn't install it themselves got `any` for those enum parameters instead of the intended literal typing. Moved to `dependencies` so it's installed automatically.

It stays **type-only** — every import in `src` is `import type`, so nothing from it lands in the runtime bundle (verified: `dist/index.*` has no reference to it). This only makes the types resolve out of the box; the "zero runtime deps" claim still holds.

Why a plain `dependency` and not a `peerDependency`: a peer (especially optional) leaves strict / non-npm setups without it installed, back at `any`. A dependency guarantees resolution for everyone.

## 2. Migration guide: v2 → v3

I originally wrote the guide as "v1 → v2" based on the PR name — but the positional API shipped as the 2.x line and the object-args rewrite released as **3.0.0**, so it's a **v2 → v3** migration. Relabeled every reference in `MIGRATION.md`; content unchanged. Also fixed the demo's "Why v2" badge → "Why v3".

## 3. Honest dependency copy in the demo

Since there's now a (type-only) dependency, the hero eyebrow "Zero dependencies" was no longer strictly true. Changed it to **"No runtime deps"**, and the feature card now notes the one dependency is type-only and never ships in the bundle.

## Verification

- `tsc -p tsconfig.json` clean, **79/79** tests
- Library + pages builds clean; `dist` confirmed to have **no runtime reference** to pogo-protos
- Frozen install passes the release-age + build-script policies (CI parity)
- Lockfile reclassifies pogo-protos under `dependencies`, resolved 2.247.0 (age-compliant)

Merging will let semantic-release cut a **patch** (3.0.1) from the `fix:` commit, publishing the dependency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)