### PR TITLE
docs: README header, badges, and npm discoverability metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # uicons.js
 
-uicons.js is a JavaScript class based on the [UICONS](https://github.com/UIcons/UIcons) specification. It provides a simple way to utilize the UICONS standard in your projects and reduces the need for tedious boilerplate code.
+**Type-safe UICONS client for Pokémon GO — resolves icon & audio URLs to exact template-literal types, with no runtime dependencies.**
+
+[![npm version](https://img.shields.io/npm/v/uicons.js.svg?logo=npm&color=cb3837)](https://www.npmjs.com/package/uicons.js)
+[![npm downloads](https://img.shields.io/npm/dm/uicons.js.svg?color=cb3837)](https://www.npmjs.com/package/uicons.js)
+[![minzipped size](https://img.shields.io/bundlejs/size/uicons.js?color=44cc11)](https://bundlejs.com/?q=uicons.js)
+[![types included](https://img.shields.io/npm/types/uicons.js.svg?color=3178c6)](https://www.npmjs.com/package/uicons.js)
+[![license](https://img.shields.io/npm/l/uicons.js.svg?color=3178c6)](./LICENSE)
+
+uicons.js is a JavaScript/TypeScript class based on the [UICONS](https://github.com/UIcons/UIcons) specification. It provides a simple way to utilize the UICONS standard in your projects and reduces the need for tedious boilerplate code.
 
 ### [Demo Page](https://turtiesocks.github.io/uicons.js/)
 
 ## Installation
-
-[![npm version](https://badge.fury.io/js/uicons.js.svg)](https://badge.fury.io/js/uicons.js)
 
 ```bash
 npm install uicons.js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,22 @@
 {
   "name": "uicons.js",
   "version": "3.0.1",
-  "description": "UICONS JavaScript Library",
+  "description": "Type-safe UICONS client for Pokémon GO — resolves icon & audio URLs to exact template-literal types, with no runtime dependencies.",
+  "keywords": [
+    "uicons",
+    "pokemon-go",
+    "pokemongo",
+    "pogo",
+    "pokemon",
+    "icons",
+    "audio",
+    "typescript",
+    "type-safe",
+    "template-literal-types",
+    "assets",
+    "asset-management",
+    "esm"
+  ],
   "repository": "https://github.com/TurtIeSocks/uicons.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",
   "homepage": "https://TurtIeSocks.github.io/uicons.js/",


### PR DESCRIPTION
Makes the README header, the GitHub repo, and the npm page all read consistently, and improves discoverability.

**README** (`d40eb2e`)
- Tagline under the title matching the GitHub description.
- Badges: npm version, monthly downloads, gzipped size (bundlejs), bundled TypeScript types, license.
- Removes the old `badge.fury` version badge buried under Installation.

**npm metadata** (`6cdbcb5`)
- Adds a `keywords` array mirroring the GitHub topics (uicons, pokemon-go, pokemongo, pogo, typescript, type-safe, template-literal-types, icons, audio, assets, …) for npm search.
- Replaces the generic `"UICONS JavaScript Library"` description with the same tagline.

All badge endpoints verified live: `v3.0.1`, `4.2k/month`, `2.3 kB` gzip (tree-shaken), `types: TypeScript`, `MIT`. bundlephobia → bundlejs because bundlephobia's API currently returns null for this package. `package.json` re-validated as JSON.

`docs:` only — no release triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)