### PR TITLE
feat(types): argument value suggestions in IntelliSense

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "vite",
     "build": "vite build -- -r",
     "build:ts": "vite build",
-    "test": "jest",
+    "test": "jest && node scripts/check-intellisense.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-intellisense.mjs
+++ b/scripts/check-intellisense.mjs
@@ -1,0 +1,76 @@
+// Guards the argument IntelliSense: asks the real TypeScript LanguageService
+// (the same engine editors use) what it suggests inside uicons method calls,
+// and fails if the literal vocabulary ever disappears again.
+//
+// Why this exists: completions resolve from the *instantiated* argument type,
+// and an unresolved generic instantiates to its default — which silently hides
+// the vocabulary unless it lives in the property type (see `Hint` in
+// src/types.ts). Run with: node scripts/check-intellisense.mjs
+import ts from 'typescript'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const PROBE = `
+import { UICONS } from './src/index.ts'
+
+const icons = new UICONS({ path: 'https://x.com', data: { gym: ['0.webp'] } })
+icons.gym({ teamId: "/*teamId*/" })
+icons.weather({ timeOfDay: "/*timeOfDay*/" })
+icons.reward({ questRewardType: "/*questRewardType*/" })
+icons.pokestop({ lureId: "/*lureId*/" })
+icons.type({ typeId: "/*typeId*/" })
+`
+
+// marker -> completions that must all be offered at that cursor
+const EXPECT = {
+  teamId: ['0', '1', '2', '3'],
+  timeOfDay: ['day', 'night'],
+  questRewardType: ['item', 'stardust', 'mega_resource'],
+  lureId: ['501', '502', '503', '504'],
+  typeId: ['1', '18'],
+}
+
+const probePath = path.join(ROOT, '__check_intellisense.ts')
+const files = new Map([[probePath, PROBE]])
+const configFile = ts.readConfigFile(path.join(ROOT, 'tsconfig.json'), ts.sys.readFile)
+const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, ROOT)
+
+const host = {
+  getScriptFileNames: () => [...parsed.fileNames, probePath],
+  getScriptVersion: () => '1',
+  getScriptSnapshot: (f) => {
+    if (files.has(f)) return ts.ScriptSnapshot.fromString(files.get(f))
+    return fs.existsSync(f)
+      ? ts.ScriptSnapshot.fromString(fs.readFileSync(f, 'utf8'))
+      : undefined
+  },
+  getCurrentDirectory: () => ROOT,
+  getCompilationSettings: () => parsed.options,
+  getDefaultLibFileName: (o) => ts.getDefaultLibFilePath(o),
+  fileExists: (f) => files.has(f) || ts.sys.fileExists(f),
+  readFile: (f) => (files.has(f) ? files.get(f) : ts.sys.readFile(f)),
+  readDirectory: ts.sys.readDirectory,
+  directoryExists: ts.sys.directoryExists,
+  getDirectories: ts.sys.getDirectories,
+}
+const ls = ts.createLanguageService(host, ts.createDocumentRegistry())
+
+let failed = false
+for (const [marker, expected] of Object.entries(EXPECT)) {
+  const pos = PROBE.indexOf(`/*${marker}*/`)
+  const offered = new Set(
+    (ls.getCompletionsAtPosition(probePath, pos, {})?.entries ?? []).map((e) => e.name)
+  )
+  const missing = expected.filter((v) => !offered.has(v))
+  if (missing.length) {
+    failed = true
+    console.error(`✗ ${marker}: missing suggestions [${missing.join(', ')}] (got ${offered.size} entries)`)
+  } else {
+    console.log(`✓ ${marker}: ${expected.join(', ')} all offered (${offered.size} entries)`)
+  }
+}
+
+process.exit(failed ? 1 : 0)

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,17 @@ export type EnumVal<T extends Record<number | string, number | string>> =
 
 export type StringOrNumber<T extends number | string> = `${T}` | T
 
+/**
+ * Accepts any `T` while keeping `Vocab`'s literals visible to IntelliSense.
+ *
+ * Editors resolve completions from the instantiated argument type, and an
+ * unresolved type parameter instantiates to its default — which hides the
+ * constraint's vocabulary. Putting the vocabulary in the property type fixes
+ * that, and the `& {}` keeps its constituents from being taken as the
+ * inference result for `T`, so literal arguments still infer exactly.
+ */
+export type Hint<T, Vocab extends Scalar | boolean> = T | (Vocab & {})
+
 type KeysEndingWith<T, S extends string> = {
   [K in keyof T]: K extends `${S}${infer _Suffix}` ? K : never
 }[keyof T]

--- a/src/uicons.ts
+++ b/src/uicons.ts
@@ -10,6 +10,7 @@ import type {
   LureIDs,
   Options,
   Scalar,
+  Hint,
   BackgroundUrl,
   DeviceUrl,
   GymUrl,
@@ -290,7 +291,7 @@ export class UICONS<
    * @returns the src of the background icon
    */
   background<Id extends Scalar = 0>(args?: {
-    id?: Id
+    id?: Hint<Id, EnumVal<typeof Rpc.EncounterOutProto.Background>>
   }): BackgroundUrl<Index, Path, Ext, Id>
   background(args: { id?: Scalar } = {}): string {
     const { id = 0 } = args
@@ -302,7 +303,7 @@ export class UICONS<
    * @returns the src of the device icon
    */
   device<Online extends boolean = false>(args?: {
-    online?: Online
+    online?: Hint<Online, boolean>
   }): DeviceUrl<Index, Path, Ext, Online>
   device(args: { online?: boolean } = {}): string {
     const { online = false } = args
@@ -323,21 +324,6 @@ export class UICONS<
    * @returns the src of the gym icon
    */
   gym<
-    TeamId extends EnumVal<typeof Rpc.Team> | 0 = 0,
-    TC extends TrainerCounts = 0,
-    Battle extends boolean = false,
-    Ex extends boolean = false,
-    Ar extends boolean = false,
-    Power extends boolean | EnumVal<typeof Rpc.FortPowerUpLevel> = false,
-  >(args?: {
-    teamId?: TeamId
-    trainerCount?: TC
-    inBattle?: Battle
-    ex?: Ex
-    ar?: Ar
-    power?: Power
-  }): GymUrl<Index, Path, Ext, TeamId, TC, Battle, Ex, Ar, Power>
-  gym<
     TeamId extends Scalar = 0,
     TC extends Scalar = 0,
     Battle extends boolean = false,
@@ -345,12 +331,12 @@ export class UICONS<
     Ar extends boolean = false,
     Power extends boolean | Scalar = false,
   >(args?: {
-    teamId?: TeamId
-    trainerCount?: TC
-    inBattle?: Battle
-    ex?: Ex
-    ar?: Ar
-    power?: Power
+    teamId?: Hint<TeamId, EnumVal<typeof Rpc.Team>>
+    trainerCount?: Hint<TC, TrainerCounts>
+    inBattle?: Hint<Battle, boolean>
+    ex?: Hint<Ex, boolean>
+    ar?: Hint<Ar, boolean>
+    power?: Hint<Power, boolean | EnumVal<typeof Rpc.FortPowerUpLevel>>
   }): GymUrl<Index, Path, Ext, TeamId, TC, Battle, Ex, Ar, Power>
   gym(
     args: {
@@ -385,18 +371,11 @@ export class UICONS<
    * @returns the src of the invasion icon
    */
   invasion<
-    GruntId extends EnumVal<typeof Rpc.EnumWrapper.InvasionCharacter> | 0 = 0,
-    Confirmed extends boolean = false,
-  >(args?: {
-    gruntId?: GruntId
-    confirmed?: Confirmed
-  }): InvasionUrl<Index, Path, Ext, GruntId, Confirmed>
-  invasion<
     GruntId extends Scalar = 0,
     Confirmed extends boolean = false,
   >(args?: {
-    gruntId?: GruntId
-    confirmed?: Confirmed
+    gruntId?: Hint<GruntId, EnumVal<typeof Rpc.EnumWrapper.InvasionCharacter>>
+    confirmed?: Hint<Confirmed, boolean>
   }): InvasionUrl<Index, Path, Ext, GruntId, Confirmed>
   invasion(args: { gruntId?: Scalar; confirmed?: boolean } = {}): string {
     const { gruntId = 0, confirmed = false } = args
@@ -421,11 +400,8 @@ export class UICONS<
    * @param args.typeId the pokemon type ID that is nesting, @see Rpc.HoloPokemonType
    * @returns the src of the nest icon
    */
-  nest<TypeId extends EnumVal<typeof Rpc.HoloPokemonType> | 0 = 0>(args?: {
-    typeId?: TypeId
-  }): NestUrl<Index, Path, Ext, TypeId>
   nest<TypeId extends Scalar = 0>(args?: {
-    typeId?: TypeId
+    typeId?: Hint<TypeId, EnumVal<typeof Rpc.HoloPokemonType>>
   }): NestUrl<Index, Path, Ext, TypeId>
   nest(args: { typeId?: Scalar } = {}): string {
     const { typeId = 0 } = args
@@ -444,37 +420,6 @@ export class UICONS<
    * @returns the src of the pokemon icon
    */
   pokemon<
-    Id extends EnumVal<typeof Rpc.HoloPokemonId> | 0 = 0,
-    Evolution extends EnumVal<typeof Rpc.HoloTemporaryEvolutionId> | 0 = 0,
-    Form extends EnumVal<typeof Rpc.PokemonDisplayProto.Form> | 0 = 0,
-    Costume extends EnumVal<typeof Rpc.PokemonDisplayProto.Costume> | 0 = 0,
-    Gender extends EnumVal<typeof Rpc.PokemonDisplayProto.Gender> | 0 = 0,
-    Alignment extends EnumVal<typeof Rpc.PokemonDisplayProto.Alignment> | 0 = 0,
-    Bread extends EnumVal<typeof Rpc.BreadModeEnum.Modifier> | 0 = 0,
-    Shiny extends boolean = false,
-  >(args?: {
-    pokemonId?: Id
-    evolution?: Evolution
-    form?: Form
-    costume?: Costume
-    gender?: Gender
-    alignment?: Alignment
-    bread?: Bread
-    shiny?: Shiny
-  }): PokemonUrl<
-    Index,
-    Path,
-    Ext,
-    Id,
-    Evolution,
-    Form,
-    Costume,
-    Gender,
-    Alignment,
-    Bread,
-    Shiny
-  >
-  pokemon<
     Id extends Scalar = 0,
     Evolution extends Scalar = 0,
     Form extends Scalar = 0,
@@ -484,14 +429,14 @@ export class UICONS<
     Bread extends Scalar = 0,
     Shiny extends boolean = false,
   >(args?: {
-    pokemonId?: Id
-    evolution?: Evolution
-    form?: Form
-    costume?: Costume
-    gender?: Gender
-    alignment?: Alignment
-    bread?: Bread
-    shiny?: Shiny
+    pokemonId?: Hint<Id, EnumVal<typeof Rpc.HoloPokemonId>>
+    evolution?: Hint<Evolution, EnumVal<typeof Rpc.HoloTemporaryEvolutionId>>
+    form?: Hint<Form, EnumVal<typeof Rpc.PokemonDisplayProto.Form>>
+    costume?: Hint<Costume, EnumVal<typeof Rpc.PokemonDisplayProto.Costume>>
+    gender?: Hint<Gender, EnumVal<typeof Rpc.PokemonDisplayProto.Gender>>
+    alignment?: Hint<Alignment, EnumVal<typeof Rpc.PokemonDisplayProto.Alignment>>
+    bread?: Hint<Bread, EnumVal<typeof Rpc.BreadModeEnum.Modifier>>
+    shiny?: Hint<Shiny, boolean>
   }): PokemonUrl<
     Index,
     Path,
@@ -547,32 +492,20 @@ export class UICONS<
    * @returns the src of the pokestop icon
    */
   pokestop<
-    LureId extends LureIDs = 0,
-    DisplayTypeId extends
-      | boolean
-      | EnumVal<typeof Rpc.IncidentDisplayType> = false,
-    QuestActive extends boolean | Scalar = false,
-    Ar extends boolean = false,
-    Power extends boolean | EnumVal<typeof Rpc.FortPowerUpLevel> = false,
-  >(args?: {
-    lureId?: LureId
-    displayTypeId?: DisplayTypeId
-    questActive?: QuestActive
-    ar?: Ar
-    power?: Power
-  }): PokestopUrl<Index, Path, Ext, LureId, DisplayTypeId, QuestActive, Ar, Power>
-  pokestop<
     LureId extends Scalar = 0,
     DisplayTypeId extends boolean | Scalar = false,
     QuestActive extends boolean | Scalar = false,
     Ar extends boolean = false,
     Power extends boolean | Scalar = false,
   >(args?: {
-    lureId?: LureId
-    displayTypeId?: DisplayTypeId
-    questActive?: QuestActive
-    ar?: Ar
-    power?: Power
+    lureId?: Hint<LureId, LureIDs>
+    displayTypeId?: Hint<
+      DisplayTypeId,
+      boolean | EnumVal<typeof Rpc.IncidentDisplayType>
+    >
+    questActive?: Hint<QuestActive, boolean>
+    ar?: Hint<Ar, boolean>
+    power?: Hint<Power, boolean | EnumVal<typeof Rpc.FortPowerUpLevel>>
   }): PokestopUrl<Index, Path, Ext, LureId, DisplayTypeId, QuestActive, Ar, Power>
   pokestop(
     args: {
@@ -605,22 +538,13 @@ export class UICONS<
    * @returns the src of the raid egg icon
    */
   raidEgg<
-    Level extends EnumVal<typeof Rpc.RaidLevel> | 0 = 0,
-    Hatched extends boolean = false,
-    Ex extends boolean = false,
-  >(args?: {
-    level?: Level
-    hatched?: Hatched
-    ex?: Ex
-  }): RaidEggUrl<Index, Path, Ext, Level, Hatched, Ex>
-  raidEgg<
     Level extends Scalar = 0,
     Hatched extends boolean = false,
     Ex extends boolean = false,
   >(args?: {
-    level?: Level
-    hatched?: Hatched
-    ex?: Ex
+    level?: Hint<Level, EnumVal<typeof Rpc.RaidLevel>>
+    hatched?: Hint<Hatched, boolean>
+    ex?: Hint<Ex, boolean>
   }): RaidEggUrl<Index, Path, Ext, Level, Hatched, Ex>
   raidEgg(
     args: { level?: Scalar; hatched?: boolean; ex?: boolean } = {}
@@ -648,23 +572,12 @@ export class UICONS<
     QT extends RewardTypeKeys = 'unset',
     Id extends Scalar = 0,
     Amount extends Scalar = 0,
-    Evolution extends EnumVal<typeof Rpc.HoloTemporaryEvolutionId> | 0 = 0,
-  >(args?: {
-    questRewardType?: QT
-    rewardId?: Id
-    amount?: Amount
-    evolution?: Evolution
-  }): RewardUrl<Index, Path, Ext, QT, Id, Amount, Evolution>
-  reward<
-    QT extends RewardTypeKeys = 'unset',
-    Id extends Scalar = 0,
-    Amount extends Scalar = 0,
     Evolution extends Scalar = 0,
   >(args?: {
-    questRewardType?: QT
+    questRewardType?: Hint<QT, RewardTypeKeys>
     rewardId?: Id
     amount?: Amount
-    evolution?: Evolution
+    evolution?: Hint<Evolution, EnumVal<typeof Rpc.HoloTemporaryEvolutionId>>
   }): RewardUrl<Index, Path, Ext, QT, Id, Amount, Evolution>
   reward(
     args: {
@@ -711,7 +624,7 @@ export class UICONS<
    * @returns the src of the spawnpoint icon
    */
   spawnpoint<HasTth extends boolean = false>(args?: {
-    hasTth?: HasTth
+    hasTth?: Hint<HasTth, boolean>
   }): SpawnpointUrl<Index, Path, Ext, HasTth>
   spawnpoint(args: { hasTth?: boolean } = {}): string {
     const { hasTth = false } = args
@@ -727,7 +640,7 @@ export class UICONS<
    * @returns the src of the station icon
    */
   station<Active extends boolean = false>(args?: {
-    active?: Active
+    active?: Hint<Active, boolean>
   }): StationUrl<Index, Path, Ext, Active>
   station(args: { active?: boolean } = {}): string {
     const { active = false } = args
@@ -743,7 +656,10 @@ export class UICONS<
    * @returns the src of the tappable icon, falling back to the reward item icon when tappable assets are unavailable
    */
   tappable<T extends Scalar = 'TAPPABLE_TYPE_POKEBALL'>(args?: {
-    tappableType?: T
+    tappableType?: Hint<
+      T,
+      'TAPPABLE_TYPE_POKEBALL' | (keyof typeof Rpc.Tappable.TappableType & string)
+    >
   }): TappableUrl<Index, Path, Ext, T>
   tappable(args: { tappableType?: Scalar } = {}): string {
     const { tappableType } = args
@@ -782,11 +698,8 @@ export class UICONS<
    * @param args.teamId the team ID, @see Rpc.Team
    * @returns the src of the team icon
    */
-  team<TeamId extends EnumVal<typeof Rpc.Team> | 0 = 0>(args?: {
-    teamId?: TeamId
-  }): TeamUrl<Index, Path, Ext, TeamId>
   team<TeamId extends Scalar = 0>(args?: {
-    teamId?: TeamId
+    teamId?: Hint<TeamId, EnumVal<typeof Rpc.Team>>
   }): TeamUrl<Index, Path, Ext, TeamId>
   team(args: { teamId?: Scalar } = {}): string {
     const { teamId = 0 } = args
@@ -797,11 +710,8 @@ export class UICONS<
    * @param args.typeId the pokemon type ID, @see Rpc.HoloPokemonType
    * @returns the src of the pokemon type icon
    */
-  type<TypeId extends EnumVal<typeof Rpc.HoloPokemonType> | 0 = 0>(args?: {
-    typeId?: TypeId
-  }): TypeUrl<Index, Path, Ext, TypeId>
   type<TypeId extends Scalar = 0>(args?: {
-    typeId?: TypeId
+    typeId?: Hint<TypeId, EnumVal<typeof Rpc.HoloPokemonType>>
   }): TypeUrl<Index, Path, Ext, TypeId>
   type(args: { typeId?: Scalar } = {}): string {
     const { typeId = 0 } = args
@@ -815,26 +725,19 @@ export class UICONS<
    * @returns the src of the weather icon
    */
   weather<
-    WeatherId extends
-      | EnumVal<typeof Rpc.GameplayWeatherProto.WeatherCondition>
-      | 0 = 0,
-    Severity extends
-      | EnumVal<typeof Rpc.InternalWeatherAlertProto.Severity>
-      | 0 = 0,
-    Time extends TimeOfDay = 'day',
-  >(args?: {
-    weatherId?: WeatherId
-    severityLevel?: Severity
-    timeOfDay?: Time
-  }): WeatherUrl<Index, Path, Ext, WeatherId, Severity, Time>
-  weather<
     WeatherId extends Scalar = 0,
     Severity extends Scalar = 0,
     Time extends string = 'day',
   >(args?: {
-    weatherId?: WeatherId
-    severityLevel?: Severity
-    timeOfDay?: Time
+    weatherId?: Hint<
+      WeatherId,
+      EnumVal<typeof Rpc.GameplayWeatherProto.WeatherCondition>
+    >
+    severityLevel?: Hint<
+      Severity,
+      EnumVal<typeof Rpc.InternalWeatherAlertProto.Severity>
+    >
+    timeOfDay?: Hint<Time, TimeOfDay>
   }): WeatherUrl<Index, Path, Ext, WeatherId, Severity, Time>
   weather(
     args: { weatherId?: Scalar; severityLevel?: Scalar; timeOfDay?: string } = {}

--- a/src/uicons.types.test.ts
+++ b/src/uicons.types.test.ts
@@ -324,6 +324,14 @@ describe('fallback typing without literal index data', () => {
     expect<object>(ready).toBe(blank)
   })
 
+  test('hinted args accept arbitrary scalars and keep literal inference', () => {
+    // the Hint<> vocabulary must not swallow inference: a literal outside the
+    // vocab still resolves exactly, and arbitrary scalars stay accepted
+    const loose = u.team({ teamId: 'not-a-team' })
+    type _1 = Expect<Equal<typeof loose, `${typeof BASE}/team/0.webp`>>
+    expect(loose).toBe(`${BASE}/team/0.webp`)
+  })
+
   test('trailing slashes are stripped at the type level too', () => {
     const slashed = new UICONS({
       path: 'https://example.com/uicons/',


### PR DESCRIPTION
Fixes the "no IntelliSense" gripe: `icons.gym({ teamId: "|" })` now offers the proto values — without giving up the loosely-typed args or the exact-URL inference.

## Root cause (found empirically, not the obvious one)

Editors resolve completions from the **instantiated** argument type, and an unresolved generic instantiates to its **default**. So the exact-inference generics were eating the vocabulary wholesale:

- `teamId: "|"` → nothing (default `0` has no string literals)
- `timeOfDay: "|"` → only `'day'` (the default)
- `questRewardType: "|"` → only `'unset'`

Rich constraints don't help, and completions don't merge from extra overloads (tested and rejected).

## Fix

```ts
type Hint<T, Vocab extends Scalar | boolean> = T | (Vocab & {})
```

applied to every hinted property, e.g. `teamId?: Hint<TeamId, EnumVal<typeof Rpc.Team>>`. The vocabulary lives in the property type where the completion engine can see it; the `& {}` keeps its constituents from being taken as the inference result, so:

- **literal args still infer exactly** → exact-URL return types unchanged
- **arbitrary scalars still accepted** → loose args unchanged
- **suggestions appear**: teamId `0–3`, lure IDs `501–506`, all 21 reward keys, `day/night`, tappable type names, pokemon/form/costume/… enum values, `true/false` on flags

Bonus: with the vocabulary in the property, the dual enum/scalar overloads were redundant — **every method collapsed to a single signature** (same acceptance domain, `-148` lines, cleaner hovers).

## Keeping it fixed

This regressed invisibly once, so the probe ships: `scripts/check-intellisense.mjs` drives the real TypeScript LanguageService (the same engine as VS Code) over cursor positions and fails if expected suggestions vanish. Wired into `pnpm test`, so the existing Release workflow enforces it — no CI file changes.

## Verification

- LanguageService probe: all markers offering expected values (in-quotes and bare positions)
- `tsc` clean · 79 runtime/type tests + 1 new Hint-inference regression test
- Library + pages builds clean; `Hint` flows into the emitted `.d.ts` (consumers get the same suggestions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)